### PR TITLE
Fix creation of compute pipelines with auto layout

### DIFF
--- a/lib/lib_webgpu.js
+++ b/lib/lib_webgpu.js
@@ -1561,7 +1561,7 @@ mergeInto(LibraryManager.library, {
       device['createComputePipeline'](
         debugDir(
           {
-            'layout': layout ? wgpu[layout] : GPUAutoLayoutMode,
+            'layout': layout != 1 ? wgpu[layout] : GPUAutoLayoutMode,
             'compute': {
               'module': wgpu[computeModule],
               'entryPoint': UTF8ToString(entryPoint),


### PR DESCRIPTION
This PR fixes an issue when using `wgpu_device_create_compute_pipeline`

If you look at the "auto" layout constant at 
https://github.com/juj/wasm_webgpu/blob/63e8b0c5b9618d6ff4bba46c59ccefe0852d86ec/lib/lib_webgpu.h#L1461
It has the value `1`.  However at 
https://github.com/juj/wasm_webgpu/blob/63e8b0c5b9618d6ff4bba46c59ccefe0852d86ec/lib/lib_webgpu.js#L1565
It checks for non-zero, and if so goes for `wgpu[layout]` where it should go to "auto".  I think..

I guess that check should just be `!= 1` ?
