### PR TITLE
wgpu_queue_write_buffer recreate the uint64s from 2 x uint32s

### DIFF
--- a/lib/lib_webgpu.js
+++ b/lib/lib_webgpu.js
@@ -2286,7 +2286,7 @@ mergeInto(LibraryManager.library, {
     });
   },
 
-  wgpu_queue_write_buffer: function(queue, buffer, bufferOffset, data, size) { // TODO: this function is untested. Write a test case
+  wgpu_queue_write_buffer: function(queue, buffer, bufferOffset1, bufferOffset2, data, size1, size2) { // TODO: this function is untested. Write a test case
     {{{ wdebuglog('`wgpu_queue_write_buffer(queue=${queue}, buffer=${buffer}, bufferOffset=${bufferOffset}, data=${data}, size=${size})`'); }}}
     {{{ wassert('queue != 0'); }}}
     {{{ wassert('wgpu[queue]'); }}}
@@ -2294,6 +2294,10 @@ mergeInto(LibraryManager.library, {
     {{{ wassert('buffer != 0'); }}}
     {{{ wassert('wgpu[buffer]'); }}}
     {{{ wassert('wgpu[buffer] instanceof GPUBuffer'); }}}
+
+    bufferOffset = bufferOffset1 + bufferOffset2 * 4294967296;
+    size = size1 + size2 * 4294967296;
+
     wgpu[queue]['writeBuffer'](wgpu[buffer], bufferOffset, HEAPU8, data, size);
   },
 


### PR DESCRIPTION
This PR, is an attempt to fix a problem passing the uint64s for the buffer offset and data size to `wgpu_queue_write_buffer`.  I'm not an expert in emscripten marshalling to javascript, so probably there's a smarter way to do this.  `wgpu_queue_write_buffer` accepts two uint64s, which are `double_int53_t` in `lib_webgpu.h`:
https://github.com/juj/wasm_webgpu/blob/720035d02dff54f4957351a7c990ed640b6f9a17/lib/lib_webgpu.h#L2460
But my observation is that when we get to the javascript side, it seems like there is an assumption that the parameters are 32 bits wide and hence the second word for `bufferOffset` goes into `data`.  `data` ends up in `size` and the passed in `size` is lost (off the right of the signature if you like - but probably just lower in the stack I suppose).  I've attempted to fix this by adding extra parameters to catch the passed in uint64s as 2 uint32s.  This seems to work, but probably a bit of a hack.  Hopefully you can see what I 'm trying to achieve.