### PR TITLE
First time through wgpu_canvas_context_get_current_texture was failing

### DIFF
--- a/lib/lib_webgpu.js
+++ b/lib/lib_webgpu.js
@@ -346,7 +346,9 @@ mergeInto(LibraryManager.library, {
     {{{ wassert('!canvasContext.derivedObjects || canvasContext.derivedObjects.length < 1000'); }}}
     if (canvasContext != wgpu[1]) {
       // ... and destroy previous special canvas context texture, if it was an old one.
-      _wgpu_object_destroy(1);
+      if (wgpu[1] !== undefined) {
+        _wgpu_object_destroy(1);
+      }
       wgpu[1] = canvasContext;
       canvasContext.wid = 1;
       canvasContext.derivedObjects = []; // GPUTextureViews are derived off of GPUTextures


### PR DESCRIPTION
This PR fixes an assert I was seeing with `wgpu_canvas_context_get_current_texture `

Maybe I missed something here, but the first time `wgpu_canvas_context_get_current_texture` is called I was observing that `wgpu[1]` was null and then `_wgpu_object_destroy` asserts.  This was my "fix".