### PR TITLE
Add wgpu_canvas_import_webgpu_context and wgpu_import_device

### DIFF
--- a/lib/lib_webgpu.h
+++ b/lib/lib_webgpu.h
@@ -2,6 +2,7 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/html5.h>
+#include <emscripten/val.h>
 #endif
 
 #ifdef __clang__
@@ -71,6 +72,12 @@ WGpuCanvasContext wgpu_canvas_get_webgpu_context(const char *canvasSelector NOTN
 WGpuCanvasContext wgpu_canvas_get_webgpu_context(HWND hwnd);
 #else
 #error Targeting currently unsupported platform! (no declaration for wgpu_canvas_get_webgpu_context())
+#endif
+
+// Imports a canvas context previously created by calling canvas.getContext().
+#ifdef __EMSCRIPTEN__
+WGpuCanvasContext wgpu_import_canvas_context(emscripten::EM_VAL canvasContext);
+WGpuDevice wgpu_import_device(emscripten::EM_VAL device);
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/lib/lib_webgpu.js
+++ b/lib/lib_webgpu.js
@@ -60,7 +60,7 @@ let api = {
   // Stores the given WebGPU object under a new free WebGPU object ID.
   // Returns the new ID. Can be called with a null/undefined, in which
   // case no object/ID is persisted.
-  $wgpuStore__deps: ['$wgpu', '$wgpuIdCounter'],
+  $wgpuStore__deps: ['$wgpu', '$wgpuIdCounter', '$debugDir'],
   $wgpuStore: function(object) {
     if (object) {
       // WebGPU renderer usage can burn through a lot of object IDs each rendered frame
@@ -214,6 +214,28 @@ let api = {
     );
   },
 
+  wgpu_canvas_import_webgpu_context: ['$wgpuStore'],
+  wgpu_canvas_import_webgpu_context: function(canvasContext) {
+    canvasContext = Emval.toValue(canvasContext);
+    {{{ wdebuglog('`wgpu_canvas_import_webgpu_context(canvasContext=${UTF8ToString(canvasContext)})`'); }}}
+    return wgpuStore(
+      canvasContext
+    );
+  },
+
+  wgpu_import_device__deps: ["$wgpuStore"],
+  wgpu_import_device: function(device) {
+    device = Emval.toValue(device);
+    {{{ wdebuglog('`wgpu_import_device(device=${UTF8ToString(device)})`'); }}}
+    device.derivedObjects = [];
+    wgpuStore(
+      device["queue"]
+    );
+    return wgpuStore(
+      device
+    );
+  },
+
 ////////////////////////////////////////////////////////////
 // Automatically generated with scripts/compress_strings.js:
 
@@ -322,7 +344,7 @@ let api = {
 // End of automatically generated with scripts/compress_strings.js
 //////////////////////////////////////////////////////////////////
 
-  wgpu_canvas_context_configure__deps: ['$GPUTextureAndVertexFormats', '$HTMLPredefinedColorSpaces', '$wgpuReadArrayOfWgpuObjects'],
+  wgpu_canvas_context_configure__deps: ['$GPUTextureAndVertexFormats', '$HTMLPredefinedColorSpaces', '$wgpuReadArrayOfWgpuObjects', '$debugDir'],
   wgpu_canvas_context_configure: function(canvasContext, config) {
     {{{ wdebuglog('`wgpu_canvas_context_configure(canvasContext=${canvasContext}, config=${config})`'); }}}
     {{{ wassert('canvasContext != 0'); }}}
@@ -643,7 +665,7 @@ let api = {
     return wgpu[adapter]['isFallbackAdapter'];
   },
 
-  wgpu_adapter_request_device_async__deps: ['$wgpuStore', 'wgpuFeatures', 'wgpu32BitLimitNames', 'wgpu64BitLimitNames', '$wgpuReadI53FromU64HeapIdx'],
+  wgpu_adapter_request_device_async__deps: ['$wgpuStore', 'wgpuFeatures', 'wgpu32BitLimitNames', 'wgpu64BitLimitNames', '$wgpuReadI53FromU64HeapIdx', '$debugDir'],
   wgpu_adapter_request_device_async__docs: '/** @suppress{checkTypes} */', // This function intentionally calls cb() without args.
   wgpu_adapter_request_device_async: function(adapter, descriptor, deviceCallback, userData) {
     {{{ wdebuglog('`wgpu_adapter_request_device_async(adapter: ${adapter}, deviceCallback: ${deviceCallback}, userData: ${userData})`'); }}}
@@ -709,7 +731,7 @@ let api = {
   },
 
 #if ASYNCIFY
-  wgpu_adapter_request_device_sync__deps: ['$wgpuStore', 'wgpuFeatures', 'wgpu32BitLimitNames', 'wgpu64BitLimitNames', '$wgpuReadI53FromU64HeapIdx', '$wgpuAsync'],
+  wgpu_adapter_request_device_sync__deps: ['$wgpuStore', 'wgpuFeatures', 'wgpu32BitLimitNames', 'wgpu64BitLimitNames', '$wgpuReadI53FromU64HeapIdx', '$wgpuAsync', '$debugDir'],
   wgpu_adapter_request_device_sync: function(adapter, descriptor) {
     {{{ wdebuglog('`wgpu_adapter_request_device_sync(adapter: ${adapter})`'); }}}
     {{{ wassert('adapter != 0'); }}}
@@ -884,7 +906,7 @@ let api = {
     }
   },
 
-  wgpu_device_create_shader_module__deps: ['$wgpuStoreAndSetParent', '$wgpuReadShaderModuleDescriptor'],
+  wgpu_device_create_shader_module__deps: ['$wgpuStoreAndSetParent', '$wgpuReadShaderModuleDescriptor', '$debugDir'],
   wgpu_device_create_shader_module: function(device, descriptor) {
     {{{ wdebuglog('`wgpu_device_create_shader_module(device=${device}, descriptor=${descriptor})`'); }}}
     {{{ wassert('device != 0'); }}}
@@ -946,7 +968,7 @@ let api = {
     });
   },
 
-  wgpu_device_create_buffer__deps: ['$wgpuReadI53FromU64HeapIdx', '$wgpuStoreAndSetParent'],
+  wgpu_device_create_buffer__deps: ['$wgpuReadI53FromU64HeapIdx', '$wgpuStoreAndSetParent', '$debugDir'],
   wgpu_device_create_buffer: function(device, descriptor) {
     {{{ wdebuglog('`wgpu_device_create_buffer(device=${device}, descriptor=${descriptor})`'); }}}
     {{{ wassert('device != 0'); }}}
@@ -1216,7 +1238,7 @@ let api = {
     return desc;
   },
 
-  wgpu_device_create_render_pipeline__deps: ['$wgpuReadRenderPipelineDescriptor', '$wgpuStoreAndSetParent'],
+  wgpu_device_create_render_pipeline__deps: ['$wgpuReadRenderPipelineDescriptor', '$wgpuStoreAndSetParent', '$debugDir'],
   wgpu_device_create_render_pipeline: function(device, descriptor) {
     {{{ wdebuglog('`wgpu_device_create_render_pipeline(device=${device}, descriptor=${descriptor})`'); }}}
     {{{ wassert('device != 0'); }}}
@@ -1246,7 +1268,7 @@ let api = {
     _free(e);
   },
 
-  wgpu_device_create_render_pipeline_async__deps: ['$wgpuReadRenderPipelineDescriptor', '$wgpuStoreAndSetParent', '$wgpuPipelineCreationFailed'],
+  wgpu_device_create_render_pipeline_async__deps: ['$wgpuReadRenderPipelineDescriptor', '$wgpuStoreAndSetParent', '$wgpuPipelineCreationFailed', '$debugDir'],
   wgpu_device_create_render_pipeline_async__docs: '/** @suppress{checkTypes} */', // This function intentionally calls cb() without args.
   wgpu_device_create_render_pipeline_async: function(device, descriptor, callback, userData) { // TODO: this function is untested. Write a test case
     {{{ wdebuglog('`wgpu_device_create_render_pipeline_async(device=${device}, descriptor=${descriptor}, callback=${callback}, userData=${userData})`'); }}}
@@ -1274,7 +1296,7 @@ let api = {
     );
   },
 
-  wgpu_device_create_command_encoder__deps: ['$wgpuStoreAndSetParent'],
+  wgpu_device_create_command_encoder__deps: ['$wgpuStoreAndSetParent', '$debugDir'],
   wgpu_device_create_command_encoder: function(device, descriptor) {
     {{{ wdebuglog('`wgpu_device_create_command_encoder(device=${device}, descriptor=${descriptor})`'); }}}
     {{{ wassert('device != 0'); }}}
@@ -1301,7 +1323,7 @@ let api = {
     return wgpuStoreAndSetParent(wgpu[device]['createCommandEncoder'](), wgpu[device]);
   },
 
-  wgpu_device_create_render_bundle_encoder__deps: ['$GPUTextureAndVertexFormats', '$wgpuStoreAndSetParent'],
+  wgpu_device_create_render_bundle_encoder__deps: ['$GPUTextureAndVertexFormats', '$wgpuStoreAndSetParent', '$debugDir'],
   wgpu_device_create_render_bundle_encoder: function(device, descriptor) { // TODO: this function is untested. Write a test case
     {{{ wdebuglog('`wgpu_device_create_render_bundle_encoder(device=${device}, descriptor=${descriptor})`'); }}}
     {{{ wassert('device != 0'); }}}
@@ -1336,7 +1358,7 @@ let api = {
     );
   },
 
-  wgpu_device_create_query_set__deps: ['$GPUPipelineStatisticNames', '$GPUQueryTypes', '$wgpuStoreAndSetParent'],
+  wgpu_device_create_query_set__deps: ['$GPUPipelineStatisticNames', '$GPUQueryTypes', '$wgpuStoreAndSetParent', '$debugDir'],
   wgpu_device_create_query_set: function(device, descriptor) { // TODO: this function is untested. Write a test case
     {{{ wdebuglog('`wgpu_device_create_query_set(device=${device}, descriptor=${descriptor})`'); }}}
     {{{ wassert('device != 0'); }}}
@@ -1571,7 +1593,7 @@ let api = {
     return wgpuStoreAndSetParent(bgl, device);
   },
 
-  wgpu_device_create_pipeline_layout__deps: ['$wgpuStoreAndSetParent', '$wgpuReadArrayOfWgpuObjects'],
+  wgpu_device_create_pipeline_layout__deps: ['$wgpuStoreAndSetParent', '$wgpuReadArrayOfWgpuObjects', '$debugDir'],
   wgpu_device_create_pipeline_layout: function(device, layouts, numLayouts) { // TODO: this function is untested. Write a test case
     {{{ wdebuglog('`wgpu_device_create_pipeline_layout(device=${device}, layouts=${layouts}, numLayouts=${numLayouts})`'); }}}
     {{{ wassert('device != 0'); }}}
@@ -1592,7 +1614,7 @@ let api = {
     );
   },
 
-  wgpu_device_create_bind_group__deps: ['$wgpuStoreAndSetParent', '$wgpuReadI53FromU64HeapIdx'],
+  wgpu_device_create_bind_group__deps: ['$wgpuStoreAndSetParent', '$wgpuReadI53FromU64HeapIdx', '$debugDir'],
   wgpu_device_create_bind_group: function(device, layout, entries, numEntries) {
     {{{ wdebuglog('`wgpu_device_create_bind_group(device=${device}, layout=${layout}, entries=${entries}, numEntries=${numEntries})`'); }}}
     {{{ wassert('device != 0'); }}}
@@ -1656,7 +1678,7 @@ let api = {
     return c;
   },
 
-  wgpu_device_create_compute_pipeline__deps: ['$wgpuStoreAndSetParent', '$wgpuReadConstants', '$GPUAutoLayoutMode'],
+  wgpu_device_create_compute_pipeline__deps: ['$wgpuStoreAndSetParent', '$wgpuReadConstants', '$GPUAutoLayoutMode', '$debugDir'],
   wgpu_device_create_compute_pipeline: function(device, computeModule, entryPoint, layout, constants, numConstants) { // TODO: this function is untested. Write a test case
     {{{ wdebuglog('`wgpu_device_create_compute_pipeline(device=${device}, computeModule=${computeModule}, entryPoint=${entryPoint}, layout=${layout}, constants=${constants}, numConstants=${numConstants})`'); }}}
     {{{ wassert('device != 0'); }}}
@@ -1691,7 +1713,7 @@ let api = {
     );
   },
 
-  wgpu_device_create_compute_pipeline_async__deps: ['$wgpuStoreAndSetParent', '$wgpuReadConstants', '$wgpuPipelineCreationFailed'],
+  wgpu_device_create_compute_pipeline_async__deps: ['$wgpuStoreAndSetParent', '$wgpuReadConstants', '$wgpuPipelineCreationFailed', '$debugDir'],
   wgpu_device_create_compute_pipeline_async__docs: '/** @suppress{checkTypes} */', // This function intentionally calls cb() without args.
   wgpu_device_create_compute_pipeline_async: function(device, computeModule, entryPoint, layout, constants, numConstants, callback, userDate) { // TODO: this function is untested. Write a test case
     {{{ wdebuglog('`wgpu_device_create_compute_pipeline_async(device=${device}, computeModule=${computeModule}, entryPoint=${entryPoint}, layout=${layout}, constants=${constants}, numConstants=${numConstants}, callback=${callback}, userData=${userData})`'); }}}
@@ -1737,7 +1759,7 @@ let api = {
     );
   },
 
-  wgpu_texture_create_view__deps: ['$wgpuStoreAndSetParent', '$GPUTextureAndVertexFormats', '$GPUTextureViewDimensions', '$GPUTextureAspects'],
+  wgpu_texture_create_view__deps: ['$wgpuStoreAndSetParent', '$GPUTextureAndVertexFormats', '$GPUTextureViewDimensions', '$GPUTextureAspects', '$debugDir'],
   wgpu_texture_create_view: function(texture, descriptor) {
     {{{ wdebuglog('`wgpu_texture_create_view(texture=${texture}, descriptor=${descriptor})`'); }}}
     {{{ wassert('texture != 0'); }}}
@@ -1864,7 +1886,7 @@ let api = {
     }
   },
 
-  wgpu_command_encoder_begin_render_pass__deps: ['$GPULoadOps', '$GPUStoreOps', '$wgpuReadTimestampWrites'],
+  wgpu_command_encoder_begin_render_pass__deps: ['$GPULoadOps', '$GPUStoreOps', '$wgpuReadTimestampWrites', '$debugDir'],
   wgpu_command_encoder_begin_render_pass: function(commandEncoder, descriptor) {
     {{{ wdebuglog('`wgpu_command_encoder_begin_render_pass(commandEncoder=${commandEncoder}, descriptor=${descriptor})`'); }}}
     {{{ wassert('commandEncoder != 0'); }}}


### PR DESCRIPTION
These functions allow a WebGPU context and device that were acquired in JS to be imported and used on the C++ side. This is useful in an application that might have a heavy amount of WebAssembly and wants to acquire a context and get something rendered to it before the wasm artifact has had time to load.