### PR TITLE
Updates from Unity

### DIFF
--- a/lib/lib_webgpu.h
+++ b/lib/lib_webgpu.h
@@ -48,7 +48,7 @@
 
 // This macro allows structs that contain pointers to be explicitly aligned up to 8 bytes so that
 // even in 32-bit pointer builds, struct alignments are checked to match against Wasm64 builds.
-#define _WGPU_ALIGN_TO_64BITS __attribute__((aligned(8)))
+#define _WGPU_ALIGN_TO_64BITS alignas(8)
 
 // The _WGPU_PTR_PADDING() macro pads pointers in 32-bit builds up to 64-bits so that memory layout
 // of WebGPU structures is identical in 32-bit and 64-bit builds. This way the JS side marshalling

--- a/lib/lib_webgpu.js
+++ b/lib/lib_webgpu.js
@@ -1344,14 +1344,14 @@ let api = {
       'vertex': {
         'module': wgpu[HEAPU32[vertexIdx+6]],
         // If null pointer was passed to use the default entry point name, then utf8() would return '', but spec requires undefined.
-        'entryPoint': utf8({{{ readPtr('vertexIdx') }}}) || void 0,
+        'entryPoint': utf8(HEAPU32[vertexIdx]) || void 0,
         'buffers': vertexBuffers,
         'constants': wgpuReadConstants({{{ readPtr('vertexIdx+4') }}}, HEAP32[vertexIdx+8])
       },
       'fragment': fragmentModule ? {
         'module': wgpu[fragmentModule],
         // If null pointer was passed to use the default entry point name, then utf8() would return '', but spec requires undefined.
-        'entryPoint': utf8({{{ readPtr('fragmentIdx') }}}) || void 0,
+        'entryPoint': utf8(HEAPU32[fragmentIdx]) || void 0,
         'targets': targets,
         'constants': wgpuReadConstants({{{ readPtr('fragmentIdx+4') }}}, HEAP32[fragmentIdx+8])
       } : void 0,

--- a/lib/lib_webgpu.js
+++ b/lib/lib_webgpu.js
@@ -24,7 +24,7 @@
     return parseInt(globalThis.WEBGPU_DEBUG) ? `console.error(${condition});` : '';
   }
   // Implement safe heap accesses for 2GB, 4GB and Wasm64 build modes.
-  globalThis.ptrToIdx = function(ptr, shift) {
+  globalThis._ptrToIdx = function(ptr, shift) {
     var shr = (MEMORY64 || MAXIMUM_MEMORY <= 2*1024*1024*1024) ? '>>' : '>>>';
     shift = MEMORY64 ? `${shift}n` : `${shift}`;
     var s = '';
@@ -152,7 +152,7 @@ let api = {
   $wgpuReadArrayOfWgpuObjects: function(ptr, numObjects) {
     {{{ wassert('numObjects >= 0'); }}}
     {{{ wassert('ptr != 0 || numObjects == 0'); }}} // Must be non-null pointer
-    {{{ ptrToIdx('ptr', 2); }}}
+    {{{ _ptrToIdx('ptr', 2); }}}
 
     var arrayOfObjects = new Array(numObjects);
     for(var i = 0; i < numObjects;) {
@@ -456,7 +456,7 @@ let api = {
     {{{ wassert('wgpu[canvasContext] instanceof GPUCanvasContext'); }}}
     {{{ wassert('config != 0'); }}} // Must be non-null
 
-    {{{ ptrToIdx('config', 2); }}}
+    {{{ _ptrToIdx('config', 2); }}}
 
     let desc = {
       'device': wgpu[HEAPU32[config]],
@@ -623,7 +623,7 @@ let api = {
     {{{ wassert('navigator["gpu"], "Your browser does not support WebGPU!"'); }}}
     {{{ wassert('options != 0'); }}}
 
-    {{{ ptrToIdx('options', 2); }}}
+    {{{ _ptrToIdx('options', 2); }}}
 
     let gpu = navigator['gpu'],
       powerPreference = [, 'low-power', 'high-performance'][HEAPU32[options]],
@@ -682,7 +682,7 @@ let api = {
       {{{ wassert('navigator["gpu"], "Your browser does not support WebGPU!"'); }}}
       {{{ wassert('options != 0'); }}}
 
-      {{{ ptrToIdx('options', 2); }}}
+      {{{ _ptrToIdx('options', 2); }}}
 
       let gpu = navigator['gpu'],
         powerPreference = [, 'low-power', 'high-performance'][HEAPU32[options]],
@@ -826,7 +826,7 @@ let api = {
 
     let l = wgpu[adapterOrDevice]['limits'];
 
-    {{{ ptrToIdx('limits', 2); }}}
+    {{{ _ptrToIdx('limits', 2); }}}
     for(let limitName of _wgpu64BitLimitNames) {
       {{{ wassert('l[limitName] !== undefined, `Browser WebGPU implementation incorrect: it should advertise limit ${limitName}`'); }}}
       wgpuWriteI53ToU64HeapIdx(limits, l[limitName]);
@@ -883,7 +883,7 @@ let api = {
   $wgpuReadDeviceDescriptor__deps: ['$wgpuReadSupportedLimits', '$wgpuReadQueueDescriptor', '$wgpuReadFeaturesBitfield'],
   $wgpuReadDeviceDescriptor: function(descriptor) {
     {{{ wassert('descriptor != 0'); }}}
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
 
     return {
       'requiredLimits': wgpuReadSupportedLimits(descriptor),
@@ -1052,7 +1052,7 @@ let api = {
   $wgpuReadShaderModuleDescriptor__deps: ['$wgpuReadShaderModuleCompilationHints'],
   $wgpuReadShaderModuleDescriptor: function(descriptor) {
     {{{ wassert('descriptor != 0'); }}}
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
     return {
       'code': utf8(HEAPU32[descriptor]),
       'compilationHints': wgpuReadShaderModuleCompilationHints(descriptor+2)
@@ -1137,7 +1137,7 @@ let api = {
     {{{ wassert('wgpu[device] instanceof GPUDevice'); }}}
     {{{ wassert('descriptor != 0'); }}}
     device = wgpu[device];
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
 
     let desc = {
       'size': wgpuReadI53FromU64HeapIdx(descriptor),
@@ -1280,7 +1280,7 @@ let api = {
   $wgpuReadRenderPipelineDescriptor__deps: ['$wgpuReadGpuStencilFaceState', '$wgpuReadGpuBlendComponent', '$wgpuReadI53FromU64HeapIdx', '$wgpuReadConstants', '$GPUIndexFormats', '$GPUTextureAndVertexFormats', '$GPUCompareFunctions', '$GPUPrimitiveTopologys', '$GPUAutoLayoutMode'],
   $wgpuReadRenderPipelineDescriptor: function(descriptor) {
     {{{ wassert('descriptor != 0'); }}}
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
 
     let vertexBuffers = [],
         targets = [],
@@ -1480,7 +1480,7 @@ let api = {
     {{{ wassert('wgpu[device] instanceof GPUDevice'); }}}
     {{{ wassert('descriptor != 0'); }}} // Must be non-null
     device = wgpu[device];
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
 
     let colorFormats = [],
       numColorFormats = HEAP32[descriptor],
@@ -1509,7 +1509,7 @@ let api = {
     {{{ wassert('wgpu[device] instanceof GPUDevice'); }}}
     {{{ wassert('descriptor != 0'); }}} // Must be non-null
     device = wgpu[device];
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
 
     let pipelineStatistics = [],
       numPipelineStatistics = HEAP32[descriptor+2],
@@ -1577,10 +1577,10 @@ let api = {
     {{{ wassert('descriptor != 0'); }}} // Must be non-null
     device = wgpu[device];
 
-    {{{ ptrToIdx('descriptor', 2); }}}
-    {{{ wassert('HEAPU32[descriptor+5] >= 1'); }}} // 'dimension' must be one of 1d, 2d or 3d.
-    {{{ wassert('HEAPU32[descriptor+5] <= 3'); }}} // 'dimension' must be one of 1d, 2d or 3d.
-    
+    {{{ _ptrToIdx('descriptor', 2); }}}
+    {{{ wassert('HEAPU32[descriptor+8] >= 1'); }}} // 'dimension' must be one of 1d, 2d or 3d.
+    {{{ wassert('HEAPU32[descriptor+8] <= 3'); }}} // 'dimension' must be one of 1d, 2d or 3d.
+
     let desc = {
       'viewFormats': wgpuReadArrayOfWgpuObjects({{{ readPtrFromIdx32('descriptor') }}}, HEAPU32[descriptor+2]),
       'size': [HEAP32[descriptor+3], HEAP32[descriptor+4], HEAP32[descriptor+5]],
@@ -1604,7 +1604,7 @@ let api = {
     {{{ wassert('wgpu[device] instanceof GPUDevice'); }}}
     device = wgpu[device];
 
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
     let desc = descriptor ? {
       'addressModeU': GPUAddressModes[HEAPU32[descriptor]],
       'addressModeV': GPUAddressModes[HEAPU32[descriptor+1]],
@@ -1648,7 +1648,7 @@ let api = {
     {{{ wassert('wgpu[device] instanceof GPUDevice'); }}}
     {{{ wassert('descriptor'); }}}
 
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
 
     {{{ wassert('wgpu[HEAPU32[descriptor]]'); }}}
     {{{ wassert('wgpu[HEAPU32[descriptor]] instanceof HTMLVideoElement'); }}}
@@ -1666,7 +1666,7 @@ let api = {
     {{{ wassert('numEntries >= 0'); }}}
     {{{ wassert('entries != 0 || numEntries == 0'); }}} // Must be non-null pointer
 
-    {{{ ptrToIdx('entries', 2); }}}
+    {{{ _ptrToIdx('entries', 2); }}}
     let e = [];
     while(numEntries--) {
       let entry = {
@@ -1749,7 +1749,7 @@ let api = {
     {{{ wassert('numEntries >= 0'); }}}
     {{{ wassert('entries != 0 || numEntries == 0'); }}} // Must be non-null pointer
     device = wgpu[device];
-    {{{ ptrToIdx('entries', 2); }}}
+    {{{ _ptrToIdx('entries', 2); }}}
     let e = [];
     while(numEntries--) {
       let resource = wgpu[HEAPU32[entries + 1]];
@@ -1869,7 +1869,7 @@ let api = {
     {{{ wassert('wgpu[texture]'); }}}
     {{{ wassert('wgpu[texture] instanceof GPUTexture'); }}}
 
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
 
     let desc = descriptor ? {
       'format': GPUTextureAndVertexFormats[HEAPU32[descriptor]],
@@ -2005,7 +2005,7 @@ let api = {
     {{{ wassert('wgpu[commandEncoder] instanceof GPUCommandEncoder'); }}}
     {{{ wassert('descriptor != 0'); }}}
 
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
 
     let colorAttachments = [],
       numColorAttachments = HEAP32[descriptor+4],
@@ -2046,7 +2046,7 @@ let api = {
       // If maxDrawCount is set to zero, pass in undefined to use the default value
       // (likely 50 million, but omit it in case the spec might change in the future)
       'maxDrawCount': maxDrawCount || void 0,
-      'timestampWrites': wgpuReadTimestampWrites(descriptor+10) // 5 + 9==sizeof(WGpuRenderPassDepthStencilAttachment) + 1
+      'timestampWrites': wgpuReadTimestampWrites(descriptor+15) // 14 + 1==sizeof(WGpuQuerySet) + 1
     };
     {{{ wdebugdir('desc', '`GPUCommandEncoder.beginRenderPass() with descriptor:`') }}};
     return wgpuStore(wgpu[commandEncoder]['beginRenderPass'](desc));
@@ -2061,7 +2061,7 @@ let api = {
     // descriptor may be a null pointer
 
     commandEncoder = wgpu[commandEncoder];
-    {{{ ptrToIdx('descriptor', 2); }}}
+    {{{ _ptrToIdx('descriptor', 2); }}}
 
     let desc = {
       'timestampWrites': wgpuReadTimestampWrites(descriptor)
@@ -2090,7 +2090,7 @@ let api = {
   $wgpuReadGpuImageCopyBuffer__deps: ['$wgpuReadI53FromU64HeapIdx'],
   $wgpuReadGpuImageCopyBuffer: function(ptr) {
     {{{ wassert('ptr != 0'); }}}
-    {{{ ptrToIdx('ptr', 2); }}}
+    {{{ _ptrToIdx('ptr', 2); }}}
     return {
       'offset': wgpuReadI53FromU64HeapIdx(ptr),
       'bytesPerRow': HEAP32[ptr+2],
@@ -2102,7 +2102,7 @@ let api = {
   $wgpuReadGpuImageCopyTexture__deps: ['$GPUTextureAspects'],
   $wgpuReadGpuImageCopyTexture: function(ptr) {
     {{{ wassert('ptr'); }}}
-    {{{ ptrToIdx('ptr', 2); }}}
+    {{{ _ptrToIdx('ptr', 2); }}}
     return {
       'texture': wgpu[HEAPU32[ptr]],
       'mipLevel': HEAP32[ptr+1],
@@ -2436,7 +2436,7 @@ let api = {
     {{{ wassert('wgpu[queue] instanceof GPUQueue'); }}}
     wgpu[queue]['submit'](wgpuReadArrayOfWgpuObjects(commandBuffers, numCommandBuffers));
 
-    {{{ ptrToIdx('commandBuffers', 2); }}}
+    {{{ _ptrToIdx('commandBuffers', 2); }}}
     while(numCommandBuffers--) _wgpu_object_destroy(HEAPU32[commandBuffers++]);
   },
 
@@ -2480,9 +2480,9 @@ let api = {
     {{{ wassert('source'); }}}
     {{{ wassert('destination'); }}}
 
-    {{{ ptrToIdx('source', 2); }}}
+    {{{ _ptrToIdx('source', 2); }}}
     let dest = wgpuReadGpuImageCopyTexture(destination);
-    {{{ ptrToIdx('destination', 2); }}}
+    {{{ _ptrToIdx('destination', 2); }}}
     dest['colorSpace'] = HTMLPredefinedColorSpaces[HEAP32[destination+6]];
     dest['premultipliedAlpha'] = !!HEAP32[destination+7];
 

--- a/lib/lib_webgpu_cpp11.cpp
+++ b/lib/lib_webgpu_cpp11.cpp
@@ -31,6 +31,7 @@ const WGpuTextureDescriptor WGPU_TEXTURE_DESCRIPTOR_DEFAULT_INITIALIZER = {
   WGPU_TEXTURE_DIMENSION_2D, /* dimension */
   0, /* format */
   0, /* usage */
+  0, /* unused_padding */
 };
 
 const WGpuTextureViewDescriptor WGPU_TEXTURE_VIEW_DESCRIPTOR_DEFAULT_INITIALIZER = {
@@ -132,9 +133,11 @@ const WGpuCanvasConfiguration WGPU_CANVAS_CONFIGURATION_DEFAULT_INITIALIZER = {
   WGPU_TEXTURE_USAGE_RENDER_ATTACHMENT, /* usage */
   0, /* numViewFormats */
   nullptr, /* viewFormats */
+  PTR_PAD_ZERO
   HTML_PREDEFINED_COLOR_SPACE_SRGB, /* colorSpace */
   WGPU_CANVAS_TONE_MAPPING_DEFAULT_INITIALIZER, /* toneMapping */
   WGPU_CANVAS_ALPHA_MODE_OPAQUE, /* alphaMode */
+  0 /* unused_padding */
 };
 
 const WGpuRenderPassTimestampWrites WGPU_RENDER_PASS_TIMESTAMP_WRITES_DEFAULT_INITIALIZER = {
@@ -144,13 +147,13 @@ const WGpuRenderPassTimestampWrites WGPU_RENDER_PASS_TIMESTAMP_WRITES_DEFAULT_IN
 };
 
 const WGpuRenderPassDescriptor WGPU_RENDER_PASS_DESCRIPTOR_DEFAULT_INITIALIZER = {
-  0, /* numColorAttachments */
+  0, /* maxDrawCount */
   0, /* colorAttachments */
+  0, /* unused_padding */
+  0, /* numColorAttachments */
   WGPU_RENDER_PASS_DEPTH_STENCIL_ATTACHMENT_DEFAULT_INITIALIZER, /* depthStencilAttachment */
   0, /* occlusionQuerySet */
-  0, /* maxDrawCount */
   WGPU_RENDER_PASS_TIMESTAMP_WRITES_DEFAULT_INITIALIZER, /* timestampWrites */
-  0 /* unusedPadding */
 };
 
 const WGpuColorTargetState WGPU_COLOR_TARGET_STATE_DEFAULT_INITIALIZER = {
@@ -172,12 +175,16 @@ const WGpuColorTargetState WGPU_COLOR_TARGET_STATE_DEFAULT_INITIALIZER = {
 
 const WGpuRenderPipelineDescriptor WGPU_RENDER_PIPELINE_DESCRIPTOR_DEFAULT_INITIALIZER = {
   { /* vertex */
-    0, /* module */
     nullptr, /* entryPoint */
-    0, /* numBuffers */
+    PTR_PAD_ZERO
     nullptr, /* buffers */
-    0, /* numConstants */
+    PTR_PAD_ZERO
     nullptr, /* constants */
+    PTR_PAD_ZERO
+    0, /* module */
+    0, /* numBuffers */
+    0, /* numConstants */
+    0, /* unused_padding */
   },
   { /* primitive */
     WGPU_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, /* topology */
@@ -214,15 +221,21 @@ const WGpuRenderPipelineDescriptor WGPU_RENDER_PIPELINE_DESCRIPTOR_DEFAULT_INITI
     0xFFFFFFFFu, /* mask */
     false /* alphaToCoverageEnabled */
   },
+  0, /* unused_padding */
   { /* fragment */
-    0, /* module */
     nullptr, /* entryPoint */
-    0, /* numTargets */
+    PTR_PAD_ZERO
     nullptr, /* targets */
+    PTR_PAD_ZERO
+    nullptr, /* constants */
+    PTR_PAD_ZERO
+    0, /* module */
+    0, /* numTargets */
     0, /* numConstants */
-    nullptr /* constants */
+    0, /* unused_padding */
   },
-  0 /* layout */
+  0, /* layout */
+  0, /* unused_padding */
 };
 
 extern const WGpuExtent3D WGPU_EXTENT_3D_DEFAULT_INITIALIZER = {

--- a/lib/lib_webgpu_dawn.cpp
+++ b/lib/lib_webgpu_dawn.cpp
@@ -104,6 +104,7 @@ const WGPUFeatureName WGPU_FEATURES_BITFIELD_to_Dawn[] = {
   WGPUFeatureName_DepthClipControl,
   WGPUFeatureName_Depth32FloatStencil8,
   WGPUFeatureName_TextureCompressionBC,
+  WGPUFeatureName_Undefined, // WGPU_FEATURE_TEXTURE_COMPRESSION_BC_SLICED_3D
   WGPUFeatureName_TextureCompressionETC2,
   WGPUFeatureName_TextureCompressionASTC,
   WGPUFeatureName_TimestampQuery,
@@ -112,9 +113,10 @@ const WGPUFeatureName WGPU_FEATURES_BITFIELD_to_Dawn[] = {
   WGPUFeatureName_RG11B10UfloatRenderable,
   WGPUFeatureName_BGRA8UnormStorage,
   WGPUFeatureName_Float32Filterable,
-  WGPUFeatureName_ClipDistances,
+  WGPUFeatureName_Undefined, // WGPU_FEATURE_CLIP_DISTANCES
+  WGPUFeatureName_Undefined, // WGPU_FEATURE_DUAL_SOURCE_BLENDING
 };
-const int _wgpu_num_features = 12;
+const int _wgpu_num_features = 13;
 
 const WGPUPowerPreference WGPU_POWER_PREFERENCE_to_Dawn[] = {
   WGPUPowerPreference_Undefined,


### PR DESCRIPTION
Something still isn't right, at least with create_render_pipeline.
wgpuReadRenderPipelineDescriptor gets the GPURenderPipelineDescriptor pointer.  The strings returned by `utf8({{{ readPtr('vertexIdx') }}}) || void 0` and `utf8({{{ readPtr('fragmentIdx') }}}) || void 0` are incorrect. There are probably other incorrect values.  It's not even an offset thing because descriptor.vertex.entryPoint should be the first thing in the memory pointer. I did have to fix up a couple other struct offsets, but I haven't gone through everything thoroughly.

I renamed ptrToIdx to _ptrToIdx because otherwise it was conflicting with other JS files in Unity, specifically ones that don't specify the shift argument.

The undefined feature flags in lib_webgpu_dawn are because we haven't updated our dawn lib in a while.